### PR TITLE
Fixes: XCode 12.0.1 Issue https://github.com/jriosdev/iOSDropDown/issues/88

### DIFF
--- a/iOSDropDown/Classes/iOSDropDown.swift
+++ b/iOSDropDown/Classes/iOSDropDown.swift
@@ -7,7 +7,7 @@
 //  Copyright © 2018 JRiOSdev. All rights reserved.
 //
 import UIKit
-
+@objc(JRDropDown)
 open class DropDown : UITextField{
 
     var arrow : Arrow!
@@ -402,7 +402,7 @@ extension DropDown: UITableViewDataSource {
         cell?.textLabel?.font = self.font
         cell?.textLabel?.textAlignment = self.textAlignment
         cell?.textLabel?.numberOfLines = 0
-        cell?.textLabel?.lineBreakMode = .byWrodWrapping
+        cell?.textLabel?.lineBreakMode = .byWordWrapping
         return cell!
     }
 }


### PR DESCRIPTION
- Typo: byWrodWrapping change to byWordWrapping
- Xcode 12 issue 'DropDown' has different definitions in different modules; first difference is definition in module 'iOSDropDown.Swift' found super class with type 'UITextField'


