### PR TITLE
Added Enable and Disable Arrow Functions

### DIFF
--- a/Classes/iOSDropDown.swift
+++ b/Classes/iOSDropDown.swift
@@ -338,6 +338,14 @@ open class DropDown : UITextField{
     public func listDidDisappear(completion: @escaping () -> ()) {
         TableDidDisappearCompletion = completion
     }
+    
+    public func enableArrow() {
+        self.rightViewMode = .always
+    }
+    
+    public func disableArrow() {
+        self.rightViewMode = .never
+    }
 
 }
 


### PR DESCRIPTION
Shows complete text in the UITextField, as decreasing arrow size to 0 still used to cut the displayed text after a certain length.